### PR TITLE
packer bootstrap script example

### DIFF
--- a/files/dhclient.conf
+++ b/files/dhclient.conf
@@ -1,0 +1,52 @@
+# Configuration file for /sbin/dhclient.
+#
+# This is a sample configuration file for dhclient. See dhclient.conf's
+#	man page for more information about the syntax of this file
+#	and a more comprehensive list of the parameters understood by
+#	dhclient.
+#
+# Normally, if the DHCP server provides reasonable information and does
+#	not leave anything out (like the domain name, for example), then
+#	few changes must be made to this file, if any.
+#
+
+option rfc3442-classless-static-routes code 121 = array of unsigned integer 8;
+
+send host-name = gethostname();
+request subnet-mask, broadcast-address, time-offset, routers,
+	interface-mtu, rfc3442-classless-static-routes, ntp-servers;
+
+#send dhcp-client-identifier 1:0:a0:24:ab:fb:9c;
+#send dhcp-lease-time 3600;
+#supersede domain-name "gturn.nt"
+#supersede domain-search "gturn.nt"
+#prepend domain-name-servers 127.0.0.1;
+#require subnet-mask, domain-name-servers;
+#timeout 60;
+#retry 60;
+#reboot 10;
+#select-timeout 5;
+#initial-interval 2;
+#script "/sbin/dhclient-script";
+#media "-link0 -link1 -link2", "link0 link1";
+#reject 192.33.137.209;
+
+#alias {
+#  interface "eth0";
+#  fixed-address 192.5.5.213;
+#  option subnet-mask 255.255.255.255;
+#}
+
+#lease {
+#  interface "eth0";
+#  fixed-address 192.33.137.200;
+#  medium "link0 link1";
+#  option host-name "andare.swiftmedia.com";
+#  option subnet-mask 255.255.255.0;
+#  option broadcast-address 192.33.137.255;
+#  option routers 192.33.137.250;
+#  option domain-name-servers 127.0.0.1;
+#  renew 2 2000/1/12 00:00:01;
+#  rebind 2 2000/1/12 00:00:01;
+#  expire 2 2000/1/12 00:00:01;
+#}

--- a/scripts/bootstrap.sh
+++ b/scripts/bootstrap.sh
@@ -1,0 +1,49 @@
+#!/bin/bash -x
+
+##
+## configure_eni.sh
+## wrapper script to fetch eni_ctl.sh and support files from git
+## suitable for use by packer
+##
+
+## functions
+function fetch_eni_ctl {
+  cleanup
+  git clone https://github.com/brukshut/eni_ctl /tmp/eni_ctl
+}
+
+function cleanup {
+  [[ -d /tmp/eni_ctl ]] && sudo rm -rf /tmp/eni_ctl
+}
+
+function copy_files {
+  for file in /lib/systemd/system/eni.service /etc/network/interfaces /etc/dhcp/dhclient.conf; do
+  [[ -e /tmp/eni_ctl/files/$(basename $file) ]] &&
+    ( sudo cp /tmp/eni_ctl/files/$(basename $file) $file
+      sudo chown root:root $file
+      sudo chmod 0644 $file )
+    [[ $(basename $file) == 'eni.service' ]] &&
+      ( sudo systemctl daemon-reload && sudo systemctl enable eni.service )
+  done
+
+  for script in eni_ctl.sh add_routes.sh configure_eni.sh configure_interfaces.sh; do 
+    [[ -e /tmp/eni_ctl/scripts/${script} ]] && 
+      sudo cp /tmp/eni_ctl/scripts/${script} /usr/local/sbin/${script}
+      sudo chown root:root /usr/local/sbin/${script}
+      sudo chmod 755 /usr/local/sbin/${script}
+  done
+}
+
+function configure_eni {
+  fetch_eni_ctl
+  copy_files
+  cleanup
+}
+
+## end functions
+
+## main
+
+configure_eni
+
+## end main


### PR DESCRIPTION
- Provides `bootstrap.sh`, example script for use with packer. This is a wrapper for `configure_eni.sh`
- Provides missing `dhclient.conf` options file.